### PR TITLE
Support PUT and GDX GAMS interfaces

### DIFF
--- a/pyomo/repn/plugins/gams_writer.py
+++ b/pyomo/repn/plugins/gams_writer.py
@@ -482,8 +482,8 @@ class ProblemWriter_gams(AbstractProblemWriter):
                     limcol=limcol,
                     solvelink=solvelink,
                     add_options=add_options,
-                    put_results=put_results
-                    put_results_format=put_results_format
+                    put_results=put_results,
+                    put_results_format=put_results_format,
                 )
             finally:
                 if isinstance(output_filename, string_types):

--- a/pyomo/solvers/tests/checks/test_GAMS.py
+++ b/pyomo/solvers/tests/checks/test_GAMS.py
@@ -10,7 +10,9 @@
 
 
 from pyomo.environ import *
-from pyomo.solvers.plugins.solvers.GAMS import GAMSShell, GAMSDirect
+from pyomo.solvers.plugins.solvers.GAMS import (
+    GAMSShell, GAMSDirect, gdxcc_available
+)
 import pyutilib.th as unittest
 from pyutilib.misc import capture_output
 import os, shutil
@@ -156,10 +158,16 @@ class GAMSTests(unittest.TestCase):
                                                          'model.gms')))
             self.assertTrue(os.path.exists(os.path.join(tmpdir,
                                                          'output.lst')))
-            self.assertTrue(os.path.exists(os.path.join(tmpdir,
-                                                         'GAMS_MODEL_p.gdx')))
-            self.assertTrue(os.path.exists(os.path.join(tmpdir,
-                                                         'GAMS_MODEL_s.gdx')))
+            if gdxcc_available:
+                self.assertTrue(os.path.exists(os.path.join(
+                    tmpdir, 'GAMS_MODEL_p.gdx')))
+                self.assertTrue(os.path.exists(os.path.join(
+                    tmpdir, 'results_s.gdx')))
+            else:
+                self.assertTrue(os.path.exists(os.path.join(
+                    tmpdir, 'results.dat')))
+                self.assertTrue(os.path.exists(os.path.join(
+                    tmpdir, 'resultsstat.dat')))
 
             shutil.rmtree(tmpdir)
 


### PR DESCRIPTION
## Fixes #N/A

## Summary/Motivation:
This PR (to your PR) re-adds support for the old PUT interface for the GAMS `gms` interface.  The implementation allows the user to select the format to use to retrieve the results, defaulting to the new GDX interface if it is available and falling back on the old PUT interface if it is not.

## Changes proposed in this PR:
- Support both `put` and `gdx` interfaes for retrieving results from GAMS.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
